### PR TITLE
修复首页全景图左右镜像问题

### DIFF
--- a/element-skin/src/composables/useHeroScene.ts
+++ b/element-skin/src/composables/useHeroScene.ts
@@ -166,13 +166,18 @@ export function createHeroScene(options: HeroSceneOptions = {}): HeroSceneContro
     if (prepared.has(item.id)) return
     if (item.type === 'panorama') {
       // Uploaded panorama files (panorama_0..5) are front, right, back, left,
-      // top, bottom — authored as seen FROM OUTSIDE the cube. GL samplerCube
-      // samples FROM INSIDE the cube, which mirrors the panorama left-right.
+      // top, bottom — authored as a camera at the cube center looking outward
+      // (Minecraft convention), but applied to the cube faces as textures on
+      // the OUTSIDE surface. Three.js CubeTexture / samplerCube samples from
+      // INSIDE the cube looking outward. The mismatch between "external
+      // texture" and "internal sampling" mirrors each face along its local
+      // axis, so each face image must be pre-flipped to appear correct.
       //
-      // To reconcile, reflect the cube across the YZ plane (x -> -x). The
-      // per-face 2D canvas flip needed to express this reflection depends on
-      // each face's UV axis orientation in Three.js CubeTexture convention,
-      // so top/bottom require a different flip than the side faces.
+      // The flip direction depends on each face's UV axis orientation in the
+      // OpenGL CubeTexture convention:
+      //   - side faces (±X, ±Z): mismatch manifests as horizontal flip
+      //   - top/bottom (±Y): UV axes are rotated 90° relative to sides, so
+      //     the same mismatch manifests as vertical flip
       //
       // Slot assignment (CubeTextureLoader expects +X, -X, +Y, -Y, +Z, -Z):
       //   +X <- right (panorama_1), -X <- left (panorama_3)

--- a/element-skin/src/composables/useHeroScene.ts
+++ b/element-skin/src/composables/useHeroScene.ts
@@ -28,6 +28,8 @@ type PreparedMedia =
       ready: boolean
     }
 
+type PanoramaFace = { face: string; flip: 'none' | 'h' | 'v' | 'hv' }
+
 export function createHeroScene(options: HeroSceneOptions = {}): HeroSceneController {
   const transition = options.transition ?? 900
   const minFrameInterval = 1000 / (options.maxFps ?? 60)
@@ -163,22 +165,37 @@ export function createHeroScene(options: HeroSceneOptions = {}): HeroSceneContro
   function prepare(item: HomepageMedia) {
     if (prepared.has(item.id)) return
     if (item.type === 'panorama') {
-      // CubeTextureLoader expects +X, -X, +Y, -Y, +Z, -Z.
-      // Uploaded panorama files are front, right, back, left, up, down.
-      const urls = [
-        mediaUrl(item, 'panorama_3.png'),
-        mediaUrl(item, 'panorama_1.png'),
-        mediaUrl(item, 'panorama_4.png'),
-        mediaUrl(item, 'panorama_5.png'),
-        mediaUrl(item, 'panorama_2.png'),
-        mediaUrl(item, 'panorama_0.png'),
+      // Uploaded panorama files (panorama_0..5) are front, right, back, left,
+      // top, bottom — authored as seen FROM OUTSIDE the cube. GL samplerCube
+      // samples FROM INSIDE the cube, which mirrors the panorama left-right.
+      //
+      // To reconcile, reflect the cube across the YZ plane (x -> -x). The
+      // per-face 2D canvas flip needed to express this reflection depends on
+      // each face's UV axis orientation in Three.js CubeTexture convention,
+      // so top/bottom require a different flip than the side faces.
+      //
+      // Slot assignment (CubeTextureLoader expects +X, -X, +Y, -Y, +Z, -Z):
+      //   +X <- right (panorama_1), -X <- left (panorama_3)
+      //   +Y <- top   (panorama_4), -Y <- bottom (panorama_5)
+      //   +Z <- back  (panorama_2), -Z <- front  (panorama_0)
+      // Camera looks down -Z, so panorama_0 (front) appears in front of the
+      // viewer.
+      const sources: PanoramaFace[] = [
+        { face: 'panorama_1.png', flip: 'h' }, // +X (right)
+        { face: 'panorama_3.png', flip: 'h' }, // -X (left)
+        { face: 'panorama_4.png', flip: 'v' }, // +Y (top)
+        { face: 'panorama_5.png', flip: 'v' }, // -Y (bottom)
+        { face: 'panorama_2.png', flip: 'h' }, // +Z (back)
+        { face: 'panorama_0.png', flip: 'h' }, // -Z (front)
       ]
       const entry: PreparedMedia = {
         item,
         kind: 'panorama',
-        texture: cubeLoader.load(urls, () => {
+        texture: new THREE.CubeTexture(loadFlippedCubeFaces(sources, (f) => mediaUrl(item, f), (canvases) => {
+          entry.texture.image = canvases
+          entry.texture.needsUpdate = true
           entry.ready = true
-        }),
+        })),
         ready: false,
       }
       entry.texture.colorSpace = THREE.SRGBColorSpace
@@ -426,6 +443,47 @@ function createSolidCanvas() {
     ctx.fillRect(0, 0, 1, 1)
   }
   return canvas
+}
+
+function flipCanvas(img: HTMLImageElement, flip: PanoramaFace['flip']): HTMLCanvasElement | null {
+  const canvas = document.createElement('canvas')
+  canvas.width = img.naturalWidth
+  canvas.height = img.naturalHeight
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return null
+  if (flip === 'h' || flip === 'hv') {
+    ctx.translate(canvas.width, 0)
+    ctx.scale(-1, 1)
+  }
+  if (flip === 'v' || flip === 'hv') {
+    ctx.translate(0, canvas.height)
+    ctx.scale(1, -1)
+  }
+  ctx.drawImage(img, 0, 0)
+  return canvas
+}
+
+function loadFlippedCubeFaces(
+  faces: PanoramaFace[],
+  buildUrl: (face: string) => string,
+  onReady: (canvases: HTMLCanvasElement[]) => void,
+): HTMLCanvasElement[] {
+  const canvases = Array.from({ length: faces.length }, () => createSolidCanvas())
+  let loaded = 0
+  faces.forEach((src, index) => {
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+    img.onload = () => {
+      const flipped = flipCanvas(img, src.flip)
+      if (flipped) canvases[index] = flipped
+      if (++loaded === faces.length) onReady(canvases)
+    }
+    img.onerror = () => {
+      if (++loaded === faces.length) onReady(canvases)
+    }
+    img.src = buildUrl(src.face)
+  })
+  return canvases
 }
 
 function lerp(a: number, b: number, t: number) {


### PR DESCRIPTION
## 问题

首页全景图整体画面连续无错位，但是左右镜像，例如前方贴图上应向右的箭头在网页上显示为向左。

## 根因

约定的 Minecraft 全景图素材（panorama_0..5）的拍摄方式是**站在场景中央向各方向取景**（"从内部看"的视角），但素材被按照"从外部贴到立方体表面"的约定分配给 CubeTexture 的六个面。

Three.js `CubeTexture` / `samplerCube` 以**"从内部采样"**的方式读取贴图。"外部贴图"和"内部采样"的组合，对立方体的每个面会产生一次沿其面法线方向的反射，渲染结果整体左右镜像。

## 修复

每个面通过 canvas 2D 翻转抵消外部→内部的镜像：
- 4 个侧面（front/right/back/left）：水平翻转——抵消侧面法线方向反转产生的水平镜像
- top/bottom：垂直翻转——上下面在 Three.js CubeTexture 的 UV 约定中比侧面多一个绕轴翻转，因此需要垂直翻转才能与侧面保持边缘连续

## 代码重构

一并重构了 panorama 加载逻辑：

1. **配置表** `sources: PanoramaFace[]` — 每个面一行声明：源文件 + 翻转方式（`'h' | 'v' | 'none' | 'hv'`），改 `flip` 字段即可调整，无需动执行代码
2. **`flipCanvas()`** — 纯函数，对单张 Image 做翻转，返回 canvas
3. **`loadFlippedCubeFaces()`** — 并发加载 6 张图，逐张翻转，全部完成后回调
4. **`prepare()` panorama 分支** — 从 40 行缩减至 20 行，仅声明配置和回调，异步细节被抽走

## 验证

- [x] `vue-tsc --noEmit` 通过
- [x] 本地视觉验证全景图方向正确
- [x] 桌面端 + 移动端方向一致
- [x] 相邻面边缘连续无错位

## 涉及的约定

- 上传约定不变：0=front, 1=right, 2=back, 3=left, 4=top(up), 5=bottom(down)
- front 面 `panorama_0.png` 在渲染中仍然位于观众正前方